### PR TITLE
Bump ckb-cli

### DIFF
--- a/nix/dep/ckb-cli/github.json
+++ b/nix/dep/ckb-cli/github.json
@@ -3,6 +3,6 @@
   "repo": "ckb-cli",
   "branch": "ledger-app",
   "private": false,
-  "rev": "26a7499dca45526fecfe103bdaa749a6e585116e",
-  "sha256": "1id83qds5pkgbnamfp9sndwk421zj4h47cfcr1drknw9qqv71lb5"
+  "rev": "0e6228a5a562d3e81d8ac802a21c56b8f524a2f2",
+  "sha256": "0bxar15nnnhidpqaayzzzybfjz0cwfl8z7vicx820hsi4dkfc1qx"
 }


### PR DESCRIPTION
This supports the new recovery id format.