### PR TITLE
Use fixed sizes in parser for stable stack use.

### DIFF
--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -346,6 +346,8 @@ bool is_self(mol_num_t num_inputs, mol_seg_t* inputs, mol_seg_t* lockScript) {
 	return false;
 }
 
+void parse_operation_inner(struct maybe_transaction* _U_ dest, bip32_path_t* _U_ key_derivation, uint8_t *const buff, uint16_t const buff_size);
+
 void parse_operation(struct maybe_transaction* _U_ dest, bip32_path_t* _U_ key_derivation, uint8_t *const buff, uint16_t const buff_size) {
 	mol_seg_t seg;
 	seg.ptr=buff;
@@ -353,6 +355,14 @@ void parse_operation(struct maybe_transaction* _U_ dest, bip32_path_t* _U_ key_d
 	uint8_t mol_result=MolReader_RawTransaction_verify(&seg,true);
 	if(mol_result != MOL_OK)
 	  REJECT("Transaction verification returned %d; parse failed\nbody: %.*h\n", mol_result, buff_size, buff);
+
+	parse_operation_inner(dest, key_derivation, buff, buff_size);
+}
+
+void parse_operation_inner(struct maybe_transaction* _U_ dest, bip32_path_t* _U_ key_derivation, uint8_t *const buff, uint16_t const buff_size) {
+	mol_seg_t seg;
+	seg.ptr=buff;
+	seg.size=buff_size;
 
 	{ // New context for stack.
 

--- a/src/blockchain.h
+++ b/src/blockchain.h
@@ -659,7 +659,6 @@ MOLECULE_API_DECORATOR mol_errno MolReader_Script_verify (const mol_seg_t *input
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
-	PRINTF("-- %x\n", &i);
         offsets[i] = mol_unpack_number(ptr);
         if (offsets[i-1] > offsets[i]) {
             return MOL_ERR_OFFSET;

--- a/src/blockchain.h
+++ b/src/blockchain.h
@@ -654,10 +654,12 @@ MOLECULE_API_DECORATOR mol_errno MolReader_Script_verify (const mol_seg_t *input
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>3) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[4];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
+	PRINTF("-- %x\n", &i);
         offsets[i] = mol_unpack_number(ptr);
         if (offsets[i-1] > offsets[i]) {
             return MOL_ERR_OFFSET;
@@ -712,7 +714,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_CellOutput_verify (const mol_seg_t *i
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>3) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[4];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -773,7 +776,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_RawTransaction_verify (const mol_seg_
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>6) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[7];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -852,7 +856,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_Transaction_verify (const mol_seg_t *
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>2) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[3];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -907,7 +912,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_UncleBlock_verify (const mol_seg_t *i
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>2) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[3];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -962,7 +968,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_Block_verify (const mol_seg_t *input,
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>4) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[5];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -1029,7 +1036,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_CellbaseWitness_verify (const mol_seg
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>2) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[3];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;
@@ -1084,7 +1092,8 @@ MOLECULE_API_DECORATOR mol_errno MolReader_WitnessArgs_verify (const mol_seg_t *
     if (input->size < MOL_NUM_T_SIZE*(field_count+1)){
         return MOL_ERR_HEADER;
     }
-    mol_num_t offsets[field_count+1];
+    if(field_count>3) return MOL_ERR_FIELD_COUNT;
+    mol_num_t offsets[4];
     offsets[0] = offset;
     for (mol_num_t i=1; i<field_count; i++) {
         ptr += MOL_NUM_T_SIZE;

--- a/src/globals.h
+++ b/src/globals.h
@@ -161,3 +161,12 @@ void update_baking_idle_screens(void);
     nvm_write((void*)&N_data, &global.apdu.baking_auth.new_data, sizeof(N_data)); \
     update_baking_idle_screens(); \
 })
+
+#ifdef NERVOS_DEBUG
+// Aid for tracking down app crashes
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define AT __FILE__ ":" TOSTRING(__LINE__)
+inline void dbgout(char* at) {int i; PRINTF("%s - sp %p spg %p %d\n", at, &i, &app_stack_canary, app_stack_canary); }
+#define DBGOUT() dbgout(AT)
+#endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -18,11 +18,3 @@
 #define ERROR_WITH_NUMBER_EXPANSION(x) char (*__kaboom)[x] = 1;
 #define SIZEOF_ERROR(x)  ERROR_WITH_NUMBER_EXPANSION(sizeof(x));
 
-#ifdef NERVOS_DEBUG
-// Aid for tracking down app crashes
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-#define AT __FILE__ ":" TOSTRING(__LINE__)
-#define DBGOUT {int i; PRINTF(AT " - sp %p spg %p %d\n", &i, &app_stack_canary, app_stack_canary); }
-#endif
-

--- a/src/types.h
+++ b/src/types.h
@@ -123,13 +123,13 @@ struct parsed_transaction {
     enum operation_tag tag;
     uint64_t total_fee;
     uint64_t amount; // 0 where inappropriate
-    uint32_t flags;  // Interpretation depends on operation type
+    uint8_t flags;  // Interpretation depends on operation type
     uint8_t source[20];
     uint8_t dao_source[20];
     uint8_t destination[20];
     uint8_t dao_destination[20];
     uint64_t dao_amount;
-    uint32_t group_input_count;
+    uint8_t group_input_count;
 };
 
 // Maximum number of APDU instructions


### PR DESCRIPTION
Also includes some breakdown of parse_operation so that we call
MolReader_RawTransaction_verify on a smaller stack and thus do not run
out of stack space.