### PR TITLE
mjr-devchain-instructions-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ then modify the value at the end of ckb-miner.toml to be small:
 value = 20
 ```
 
-and uncomment the block_assembler block at the end of ckb.toml:
+and uncomment the block_assembler block at the end of ckb.toml and change the 'message' to '0x':
 
 ```
 [block_assembler]


### PR DESCRIPTION
Noted that the 'message' in ckb.toml should be set to 0x