### PR TITLE
Skip memcpy when parse failed

### DIFF
--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -576,9 +576,9 @@ static size_t handle_apdu(bool const enable_hashing, bool const enable_parsing, 
         THROW(EXC_WRONG_PARAM);
     }
 
-    if (enable_parsing) {
-        if (!G.maybe_transaction.parse_failed && G.to_parse_fill_idx + buff_size > MAX_TOSIGN_PARSED) {
-            PRINTF("Transaction body too big; can't parse.");
+    if (enable_parsing && !G.maybe_transaction.parse_failed) {
+        if (G.to_parse_fill_idx + buff_size > MAX_TOSIGN_PARSED) {
+            PRINTF("Transaction body too big; can't parse.\n");
             G.maybe_transaction.parse_failed = true;
         } else {
             memcpy(G.to_parse + G.to_parse_fill_idx, buff, buff_size);

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -567,8 +567,10 @@ static size_t handle_apdu(bool const enable_hashing, bool const enable_parsing, 
             THROW(EXC_WRONG_LENGTH_FOR_INS);
 
         // Guard against overflow
-        if (G.packet_index >= 0xFF)
+        if (G.packet_index >= 0xFF) {
+            PRINTF("Packet overflow.\n");
             PARSE_ERROR();
+        }
         G.packet_index++;
 
         break;


### PR DESCRIPTION
This avoids the crash seen on ledger transfer with a devnet ledger miner. Unfortunately we still hit the packet overflow error even with this fix. Somehow too many cells are coming through.