### PR TITLE
Don’t add trailing slash for last derivation path part

### DIFF
--- a/src/apdu_pubkey.c
+++ b/src/apdu_pubkey.c
@@ -40,8 +40,10 @@ static void bip32_path_to_string(char *const out, size_t const out_size, apdu_pu
             bound_check_buffer(out_current_offset, out_size);
             out[out_current_offset++] = '\'';
         }
-        bound_check_buffer(out_current_offset, out_size);
-        out[out_current_offset++] = '/';
+        if (i < pubkey->key.length - 1) {
+            bound_check_buffer(out_current_offset, out_size);
+            out[out_current_offset++] = '/';
+        }
         bound_check_buffer(out_current_offset, out_size);
         out[out_current_offset] = '\0';
     }


### PR DESCRIPTION
We usually show derivations paths like:

  44'/309'/0'/1/0

instead of:

  44'/309'/0'/1/0/

Even those are identical, skipping it here avoids confusing the user.