### PR TITLE
Bump ckb-cli with fix: Show '0x' in front of lock_arg on account import

### DIFF
--- a/nix/dep/ckb-cli/github.json
+++ b/nix/dep/ckb-cli/github.json
@@ -3,6 +3,6 @@
   "repo": "ckb-cli",
   "branch": "ledger-app",
   "private": false,
-  "rev": "3ce23b548f992158bc73e357f25c44030445ca44",
-  "sha256": "186rxy01hn9hhsh7lk7d9i5hsvzi2pj9mmhjs6jk3fwgcmhy2dka"
+  "rev": "561994e33d20e25f485c2368bbaccc306d7153c5",
+  "sha256": "1x7x5s5iz6lf2ffxkpvwpf30nq8wb13mr93hki4d5d4b9wlvd046"
 }


### PR DESCRIPTION
Also contains some fixes to the internals of ledger account management.