### PR TITLE
Clarify udev and mac relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are using this application with a wallet, please refer to that wallet's s
 
 ## Preparing Your Linux Machine for Ledger Device Communication
 
-On Linux, the "udev" rules must be set up to allow your user to communicate with the ledger device.
+On Linux, the "udev" rules must be set up to allow your user to communicate with the ledger device. MacOS devices do not need any configuration to communicate with a Ledger device, so if you are using Mac you can ignore this section.
 
 ### NixOS
 


### PR DESCRIPTION
In our docs we discussion special steps that must be taken in order for a linux machine to communicate with a Ledger device. Mac machines do not need any special configuration, but this isn't clearly stated in the docs. This PR addresses that.