### PR TITLE
Add message-hash signing apdu

### DIFF
--- a/src/apdu.h
+++ b/src/apdu.h
@@ -30,6 +30,7 @@
 #define INS_PROMPT_EXT_PUBLIC_KEY     0x04
 #define INS_ACCOUNT_IMPORT            0x05
 #define INS_SIGN_MESSAGE              0x06
+#define INS_SIGN_MESSAGE_HASH         0x07
 #define INS_GIT                       0x09
 #define INS_SIGN_WITH_HASH            0x0F
 

--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -871,12 +871,10 @@ static int perform_signature(bool const on_hash, bool const send_hash) {
 
 /***********************************************************/
 static inline void clear_message_data(void) {
-  // Use for both sign_message and sign_message_hash
   memset(&global.apdu.u.sign_msg, 0, sizeof(global.apdu.u.sign_msg));
 }
 
 static inline void clear_message_hash_data(void) {
-  // Use for both sign_message and sign_message_hash
   memset(&global.apdu.u.sign_msg_hash, 0, sizeof(global.apdu.u.sign_msg_hash));
 }
 
@@ -907,7 +905,7 @@ static bool check_magic_bytes(uint8_t const * message, uint8_t message_len) {
 static void copy_buffer(char *const out, size_t const out_size, buffer_t const *const in) {
   if(in->size > out_size) THROW(EXC_MEMORY_ERROR);
 
-  // if we dont do this we have stuff from the old buffer getting displayed
+  // if we dont do this then we have stuff from the old buffer getting displayed
   memset(out, 0, out_size);
   memcpy(out, in->bytes, in->size);
 }

--- a/src/apdu_sign.h
+++ b/src/apdu_sign.h
@@ -5,3 +5,4 @@
 size_t handle_apdu_sign(uint8_t instruction);
 size_t handle_apdu_sign_with_hash(uint8_t instruction);
 size_t handle_apdu_sign_message(uint8_t instruction);
+size_t handle_apdu_sign_message_hash(uint8_t instruction);

--- a/src/globals.h
+++ b/src/globals.h
@@ -123,6 +123,13 @@ typedef struct {
 
 typedef struct {
     bip32_path_t key;
+    buffer_t display_as_buffer;
+    uint8_t hash_to_sign[64];  // Max message hash size we accept = 64 bytes
+    uint8_t hash_to_sign_size;
+} apdu_sign_message_hash_state_t;
+
+typedef struct {
+    bip32_path_t key;
     extended_public_key_t ext_public_key;
     cx_blake2b_t hash_state;
 } apdu_pubkey_state_t;
@@ -174,6 +181,7 @@ typedef struct {
             apdu_pubkey_state_t pubkey;
             apdu_sign_state_t sign;
             apdu_sign_message_state_t sign_msg;
+            apdu_sign_message_hash_state_t sign_msg_hash;
             apdu_account_import_state_t account_import;
         } u;
 

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@ __attribute__((noreturn)) void app_main(void) {
     global.handlers[APDU_INS(INS_PROMPT_EXT_PUBLIC_KEY)] = handle_apdu_get_public_key;
     global.handlers[APDU_INS(INS_ACCOUNT_IMPORT)] = handle_apdu_account_import;
     global.handlers[APDU_INS(INS_SIGN_MESSAGE)] = handle_apdu_sign_message;
+    global.handlers[APDU_INS(INS_SIGN_MESSAGE_HASH)] = handle_apdu_sign_message_hash;
     global.handlers[APDU_INS(INS_SIGN)] = handle_apdu_sign;
     global.handlers[APDU_INS(INS_GIT)] = handle_apdu_git;
     if(!N_data.initialized) {


### PR DESCRIPTION
Supports message-hash signing. Takes a hash with a 64byte or less size and signs it