### PR TITLE
Fix non-multisig addresses showing as multisig.

### DIFF
--- a/src/apdu_sign.c
+++ b/src/apdu_sign.c
@@ -119,7 +119,7 @@ static void multi_output_prompts_cb(size_t which) {
                 // Maximum of 28
                 value_fill+=sizeof(separator)-1;
 
-                void (*lock_arg_to_destination_address)(char *const, size_t const, lock_arg_t const *const) = G.u.tx.sending_to_multisig_output ? lock_arg_to_multisig_address : lock_arg_to_sighash_address;
+                void (*lock_arg_to_destination_address)(char *const, size_t const, lock_arg_t const *const) = G.u.tx.outputs[which-3].is_multisig ? lock_arg_to_multisig_address : lock_arg_to_sighash_address;
                 lock_arg_to_destination_address(global.ui.prompt.active_value+value_fill, sizeof(global.ui.prompt.active_value), &G.u.tx.outputs[which-3].destination);
             }
     }
@@ -128,19 +128,9 @@ static void multi_output_prompts_cb(size_t which) {
 #define MAX_NUMBER_CHARS (MAX_INT_DIGITS + 2) // include decimal point and terminating null
 
 static size_t sign_complete(uint8_t instruction) {
-    static size_t const TYPE_INDEX = 0;
-    static size_t const HASH_INDEX = 1;
-
-    static const char *const parse_fail_prompts[] = {
-        PROMPT("Unrecognized"),
-        PROMPT("Sign Hash"),
-        NULL,
-    };
-
-    REGISTER_STATIC_UI_VALUE(TYPE_INDEX, "Operation");
 
     ui_callback_t const ok_c = instruction == INS_SIGN_WITH_HASH ? sign_with_hash_ok : sign_without_hash_ok;
-    void *lock_arg_to_destination_address_cb = G.u.tx.sending_to_multisig_output ? lock_arg_to_multisig_address : lock_arg_to_sighash_address;
+    void *lock_arg_to_destination_address_cb = G.u.tx.outputs[0].is_multisig ? lock_arg_to_multisig_address : lock_arg_to_sighash_address;
 
     switch (G.maybe_transaction.v.tag) {
 
@@ -556,23 +546,22 @@ void output_end(void) {
         memcpy(&G.dao_cell_owner, &G.lock_arg_tmp.hash, sizeof(G.lock_arg_tmp.hash));
         G.u.tx.dao_output_amount += G.cell_state.capacity;
         G.u.tx.dao_bitmask |= 1<<G.u.tx.current_output_index;
-        if(G.cell_state.lock_arg_nonequal)
+        if(G.cell_state.lock_arg_nonequal || G.cell_state.is_multisig)
             REJECT("Not allowing DAO outputs to be sent to a non-self address");
         G.maybe_transaction.v.flags |= HAS_CHANGE_ADDRESS;
     } else {
-        if(G.cell_state.is_multisig) {
-            G.u.tx.sending_to_multisig_output = true;
-        }
         // if the output lock arg doesn't match the change bip-32 path
-        if(G.cell_state.lock_arg_nonequal) {
+        if(G.cell_state.lock_arg_nonequal || G.cell_state.is_multisig) {
             if (!(G.maybe_transaction.v.flags & HAS_DESTINATION_ADDRESS) ) {
                 if (G.u.tx.output_count != 0) {
                     // Should be 0 if we haven't seent address yet
                     THROW(EXC_MEMORY_ERROR);
                 }
+                G.u.tx.outputs[0].is_multisig = G.cell_state.is_multisig;
                 memcpy(&G.u.tx.outputs[0].destination, &G.lock_arg_tmp, sizeof(lock_arg_t));
                 G.u.tx.output_count++; // we found the first output
-            } else if(memcmp(G.u.tx.outputs[0].destination.hash, G.lock_arg_tmp.hash, 20)) {
+            } else if(memcmp(G.u.tx.outputs[G.u.tx.output_count-1].destination.hash, G.lock_arg_tmp.hash, 20)
+                      || G.u.tx.outputs[G.u.tx.output_count-1].is_multisig != G.cell_state.is_multisig) {
                 // Not the same as last output, so cannot coalesce and need to
                 // make new prompt / cell in our output array.
                 if(G.maybe_transaction.v.tag != OPERATION_TAG_NOT_SET
@@ -580,8 +569,9 @@ void output_end(void) {
                     REJECT("Can't handle mixed transaction types with multiple non-change destination addresses. Tag: %d", G.maybe_transaction.v.tag);
                 G.maybe_transaction.v.tag = OPERATION_TAG_MULTI_OUTPUT_TRANSFER;
                 if(G.u.tx.output_count>=MAX_OUTPUTS) REJECT("Can't handle more than five outputs");
+                G.u.tx.outputs[G.u.tx.output_count].is_multisig = G.cell_state.is_multisig;
+                memcpy(&G.u.tx.outputs[G.u.tx.output_count].destination, &G.lock_arg_tmp, sizeof(lock_arg_t));
                 G.u.tx.output_count++;
-                memcpy(&G.u.tx.outputs[G.u.tx.output_count - 1].destination, &G.lock_arg_tmp, sizeof(lock_arg_t));
             } else {
                 // Same address as last output, can reuse promopt and so do
                 // nothing here.

--- a/src/globals.h
+++ b/src/globals.h
@@ -92,7 +92,6 @@ typedef struct {
             uint8_t first_witness_done : 1;
             uint8_t is_self_transfer : 1;
             uint8_t processed_change_cell : 1; // Has at least one change-address been processed?
-            uint8_t sending_to_multisig_output : 1;
         } tx;
     } u;
 

--- a/src/types.h
+++ b/src/types.h
@@ -86,7 +86,7 @@ static inline bool bip32_paths_eq(bip32_path_t volatile const *const a, bip32_pa
 #define PKH_STRING_SIZE                  40 // includes null byte // TODO: use sizeof for this.
 #define PROTOCOL_HASH_BASE58_STRING_SIZE sizeof("ProtoBetaBetaBetaBetaBetaBetaBetaBetaBet11111a5ug96")
 
-#define MAX_SCREEN_COUNT 7 // Current maximum usage
+#define MAX_SCREEN_COUNT 8 // Current maximum usage
 #define PROMPT_WIDTH     16
 #define VALUE_WIDTH      128 // Needs to hold a 32 bytes of hash in hex.
 
@@ -161,6 +161,7 @@ typedef union {
 struct output_t {
 	uint64_t capacity;
 	lock_arg_t destination;
+  uint8_t is_multisig : 1;
 };
 
 // Have we found an output cell which doesn't correspond to the change

--- a/src/ui.c
+++ b/src/ui.c
@@ -173,6 +173,7 @@ PROMPT_SCREEN_TPL(3);
 PROMPT_SCREEN_TPL(4);
 PROMPT_SCREEN_TPL(5);
 PROMPT_SCREEN_TPL(6);
+PROMPT_SCREEN_TPL(7);
 
 static void prompt_response(bool const accepted) {
     ui_initial_screen();
@@ -209,6 +210,7 @@ UX_FLOW(ux_prompts_flow,
     &PROMPT_SCREEN_NAME(4),
     &PROMPT_SCREEN_NAME(5),
     &PROMPT_SCREEN_NAME(6),
+    &PROMPT_SCREEN_NAME(7),
     &ux_prompt_flow_reject_step,
     &ux_prompt_flow_accept_step
 );
@@ -281,6 +283,7 @@ void ui_prompt(const char *const *labels, ui_callback_t ok_c, ui_callback_t cxl_
 
 __attribute__((noreturn)) void ui_prompt_with_cb(void (*switch_screen_cb)(uint32_t), size_t screen_count, ui_callback_t ok_c, ui_callback_t cxl_c) {
     check_null(switch_screen_cb);
+    if(screen_count>MAX_SCREEN_COUNT) THROW(EXC_MEMORY_ERROR);
 
     G.switch_screen=switch_screen_cb;
     G.prompt.offset=MAX_SCREEN_COUNT-screen_count;

--- a/tests/multi-output.js
+++ b/tests/multi-output.js
@@ -556,7 +556,15 @@ describe("Multi-output transaction signing", () => {
     await flow.promptsPromise;
   });
 
-  it("Signing with more than five output to distinct destinations rejects.", async function() {
+  it("Signing with five outputs to distinct destinations passes and shows each output.", async function() {
+    const signPath = [
+      2147483692,
+      2147483957,
+      2147483648,
+      0,
+      0
+    ];
+
     const txn = {
       "signPath": [
         2147483692,
@@ -571,6 +579,209 @@ describe("Multi-output transaction signing", () => {
         2147483648,
         0,
         0
+      ],
+      "inputCount": 1,
+      "raw": {
+        "version": 0,
+        "cell_deps": [
+          {
+            "out_point": {
+              "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+              "index": 2
+            },
+            "dep_type": 0
+          },
+          {
+            "out_point": {
+              "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+              "index": 0
+            },
+            "dep_type": 1
+          }
+        ],
+        "header_deps": [],
+        "inputs": [
+          {
+            "input": {
+              "since": "0000000000000000",
+              "previous_output": {
+                "tx_hash": "b1b547956a0dfb7ea618231563b3acd23607586e939f88e5a6db5f392b2e78d5",
+                "index": 1
+              }
+            },
+            "source": {
+              "version": 0,
+              "cell_deps": [
+                {
+                  "out_point": {
+                    "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+                    "index": 2
+                  },
+                  "dep_type": 0
+                },
+                {
+                  "out_point": {
+                    "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+                    "index": 0
+                  },
+                  "dep_type": 1
+                }
+              ],
+              "header_deps": [
+                "327f1fc62c53530c6c27018f1e8cee27c35c0370c3b4d3376daf8fe110e7d8cb"
+              ],
+              "inputs": [
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c399495011b912999dbc72cf54982924e328ae170654ef76c8aba190ca376307",
+                    "index": 0
+                  }
+                },
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c317d0b0b2a513ab1206e6d454c1960de7d7b4b80d0748a3e1f9cb197b74b8a5",
+                    "index": 1
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "capacity": "000000174876e800",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": {
+                    "code_hash": "82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+                    "hash_type": 1,
+                    "args": ""
+                  }
+                },
+                {
+                  "capacity": "0000001773b2e564",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": null
+                }
+              ],
+              "outputs_data": [
+                "5207000000000000",
+                ""
+              ]
+            }
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863a"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863b"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863c"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "000000002b3bf97c",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe8610"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe8611"
+            },
+            "type_": null
+          }
+        ],
+        "outputs_data": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      },
+      "witnesses": [
+        ""
+      ]
+    };
+
+    const flow = await flowAccept(this.speculos, [
+      {header:"Confirm", body:"Transaction"},
+      {header:"Amount", body:"1000"},
+      {header:"Fee", body:"0.00001"},
+      {header:"Output 1/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scaqc8pnyu"},
+      {header:"Output 2/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scasdxft30"},
+      {header:"Output 3/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7sc7qffs5ek"},
+      {header:"Output 4/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scgqyqay7e"},
+      {header:"Output 5/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scgs3p4ut2"}
+    ]);
+
+    const sig = await this.ckb.signAnnotatedTransaction(txn);
+    const key = await getKeyFromLedgerCached(this, signPath);
+
+    checkSignature(txn, sig, key);
+
+    await flow.promptsPromise;
+  });
+
+  it("Signing with more than five output to distinct destinations rejects.", async function() {
+    const txn = {
+      "signPath": [
+        2147483692,
+        2147483957,
+        2147483648,
+        0,
+        0
+      ],
+      "changePath": [
+        2147483692,
+        2147483957,
+        2147483648,
+        0,
+        1
       ],
       "inputCount": 1,
       "raw": {
@@ -739,6 +950,8 @@ describe("Multi-output transaction signing", () => {
           "",
           "",
           "",
+          "",
+          "",
           ""
         ]
       },
@@ -754,5 +967,216 @@ describe("Multi-output transaction signing", () => {
       expect(e).has.property('statusCode', 0x6985);
       expect(e).has.property('statusText', 'CONDITIONS_OF_USE_NOT_SATISFIED');
     }
+  });
+
+it("Signing with mixed sighash and multisig formats each output correctly.", async function() {
+    const signPath = [
+      2147483692,
+      2147483957,
+      2147483648,
+      0,
+      0
+    ];
+
+    const txn = {
+      "signPath": [
+        2147483692,
+        2147483957,
+        2147483648,
+        0,
+        0
+      ],
+      "changePath": [
+        2147483692,
+        2147483957,
+        2147483648,
+        0,
+        0
+      ],
+      "inputCount": 1,
+      "raw": {
+        "version": 0,
+        "cell_deps": [
+          {
+            "out_point": {
+              "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+              "index": 2
+            },
+            "dep_type": 0
+          },
+          {
+            "out_point": {
+              "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+              "index": 0
+            },
+            "dep_type": 1
+          }
+        ],
+        "header_deps": [],
+        "inputs": [
+          {
+            "input": {
+              "since": "0000000000000000",
+              "previous_output": {
+                "tx_hash": "b1b547956a0dfb7ea618231563b3acd23607586e939f88e5a6db5f392b2e78d5",
+                "index": 1
+              }
+            },
+            "source": {
+              "version": 0,
+              "cell_deps": [
+                {
+                  "out_point": {
+                    "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+                    "index": 2
+                  },
+                  "dep_type": 0
+                },
+                {
+                  "out_point": {
+                    "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+                    "index": 0
+                  },
+                  "dep_type": 1
+                }
+              ],
+              "header_deps": [
+                "327f1fc62c53530c6c27018f1e8cee27c35c0370c3b4d3376daf8fe110e7d8cb"
+              ],
+              "inputs": [
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c399495011b912999dbc72cf54982924e328ae170654ef76c8aba190ca376307",
+                    "index": 0
+                  }
+                },
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c317d0b0b2a513ab1206e6d454c1960de7d7b4b80d0748a3e1f9cb197b74b8a5",
+                    "index": 1
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "capacity": "000000174876e800",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": {
+                    "code_hash": "82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+                    "hash_type": 1,
+                    "args": ""
+                  }
+                },
+                {
+                  "capacity": "0000001773b2e564",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": null
+                }
+              ],
+              "outputs_data": [
+                "5207000000000000",
+                ""
+              ]
+            }
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863a"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863b"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863c"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "000000002b3bf97c",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe8611"
+            },
+            "type_": null
+          }
+        ],
+        "outputs_data": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      },
+      "witnesses": [
+        ""
+      ]
+    };
+
+    const flow = await flowAccept(this.speculos, [
+      {header:"Confirm", body:"Transaction"},
+      {header:"Amount", body:"1000"},
+      {header:"Fee", body:"0.00001"},
+      {header:"Output 1/5", body:"200 CKB -> ckb1qyq72fsdswd8s6kz4yy3s80e5s3lrma7scaqvts8tg"},
+      {header:"Output 2/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scasdxft30"},
+      {header:"Output 3/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7sc7qffs5ek"},
+      {header:"Output 4/5", body:"200 CKB -> ckb1qyq72fsdswd8s6kz4yy3s80e5s3lrma7sc7sgyfcr3"},
+      {header:"Output 5/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scgs3p4ut2"}
+    ]);
+
+    const sig = await this.ckb.signAnnotatedTransaction(txn);
+    const key = await getKeyFromLedgerCached(this, signPath);
+
+    checkSignature(txn, sig, key);
+
+    await flow.promptsPromise;
   });
 });

--- a/tests/multi-output.js
+++ b/tests/multi-output.js
@@ -566,13 +566,7 @@ describe("Multi-output transaction signing", () => {
     ];
 
     const txn = {
-      "signPath": [
-        2147483692,
-        2147483957,
-        2147483648,
-        0,
-        0
-      ],
+      signPath,
       "changePath": [
         2147483692,
         2147483957,
@@ -979,13 +973,7 @@ it("Signing with mixed sighash and multisig formats each output correctly.", asy
     ];
 
     const txn = {
-      "signPath": [
-        2147483692,
-        2147483957,
-        2147483648,
-        0,
-        0
-      ],
+      signPath,
       "changePath": [
         2147483692,
         2147483957,
@@ -1166,6 +1154,210 @@ it("Signing with mixed sighash and multisig formats each output correctly.", asy
       {header:"Amount", body:"1000"},
       {header:"Fee", body:"0.00001"},
       {header:"Output 1/5", body:"200 CKB -> ckb1qyq72fsdswd8s6kz4yy3s80e5s3lrma7scaqvts8tg"},
+      {header:"Output 2/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scasdxft30"},
+      {header:"Output 3/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7sc7qffs5ek"},
+      {header:"Output 4/5", body:"200 CKB -> ckb1qyq72fsdswd8s6kz4yy3s80e5s3lrma7sc7sgyfcr3"},
+      {header:"Output 5/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scgs3p4ut2"}
+    ]);
+
+    const sig = await this.ckb.signAnnotatedTransaction(txn);
+    const key = await getKeyFromLedgerCached(this, signPath);
+
+    checkSignature(txn, sig, key);
+
+    await flow.promptsPromise;
+  });
+it("Signing with mixed sighash, multisig, and multisig with since formats each output correctly.", async function() {
+    const signPath = [
+      2147483692,
+      2147483957,
+      2147483648,
+      0,
+      0
+    ];
+
+    const txn = {
+      signPath,
+      "changePath": [
+        2147483692,
+        2147483957,
+        2147483648,
+        0,
+        0
+      ],
+      "inputCount": 1,
+      "raw": {
+        "version": 0,
+        "cell_deps": [
+          {
+            "out_point": {
+              "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+              "index": 2
+            },
+            "dep_type": 0
+          },
+          {
+            "out_point": {
+              "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+              "index": 0
+            },
+            "dep_type": 1
+          }
+        ],
+        "header_deps": [],
+        "inputs": [
+          {
+            "input": {
+              "since": "0000000000000000",
+              "previous_output": {
+                "tx_hash": "b1b547956a0dfb7ea618231563b3acd23607586e939f88e5a6db5f392b2e78d5",
+                "index": 1
+              }
+            },
+            "source": {
+              "version": 0,
+              "cell_deps": [
+                {
+                  "out_point": {
+                    "tx_hash": "a563884b3686078ec7e7677a5f86449b15cf2693f3c1241766c6996f206cc541",
+                    "index": 2
+                  },
+                  "dep_type": 0
+                },
+                {
+                  "out_point": {
+                    "tx_hash": "ace5ea83c478bb866edf122ff862085789158f5cbff155b7bb5f13058555b708",
+                    "index": 0
+                  },
+                  "dep_type": 1
+                }
+              ],
+              "header_deps": [
+                "327f1fc62c53530c6c27018f1e8cee27c35c0370c3b4d3376daf8fe110e7d8cb"
+              ],
+              "inputs": [
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c399495011b912999dbc72cf54982924e328ae170654ef76c8aba190ca376307",
+                    "index": 0
+                  }
+                },
+                {
+                  "since": "0000000000000000",
+                  "previous_output": {
+                    "tx_hash": "c317d0b0b2a513ab1206e6d454c1960de7d7b4b80d0748a3e1f9cb197b74b8a5",
+                    "index": 1
+                  }
+                }
+              ],
+              "outputs": [
+                {
+                  "capacity": "000000174876e800",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": {
+                    "code_hash": "82d76d1b75fe2fd9a27dfbaa65a039221a380d76c926f378d3f81cf3e7e13f2e",
+                    "hash_type": 1,
+                    "args": ""
+                  }
+                },
+                {
+                  "capacity": "0000001773b2e564",
+                  "lock": {
+                    "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+                    "hash_type": 1,
+                    "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+                  },
+                  "type_": null
+                }
+              ],
+              "outputs_data": [
+                "5207000000000000",
+                ""
+              ]
+            }
+          }
+        ],
+        "outputs": [
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863a0102030405060708"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863b"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863c"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "000000002b3bf97c",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "5c5069eb0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe863d"
+            },
+            "type_": null
+          },
+          {
+            "capacity": "00000004a817c800",
+            "lock": {
+              "code_hash": "9bd7e06f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8",
+              "hash_type": 1,
+              "args": "e5260d839a786ac2a909181df9a423f1efbe8611"
+            },
+            "type_": null
+          }
+        ],
+        "outputs_data": [
+          "",
+          "",
+          "",
+          "",
+          "",
+          "",
+          ""
+        ]
+      },
+      "witnesses": [
+        ""
+      ]
+    };
+
+    const flow = await flowAccept(this.speculos, [
+      {header:"Confirm", body:"Transaction"},
+      {header:"Amount", body:"1000"},
+      {header:"Fee", body:"0.00001"},
+      {header:"Output 1/5", body:"200 CKB -> ckb1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn323efxpkpe57r2c25sjxqalxjz8u00h6rr5qgzqvzq2ps8pqntd2cj"},
       {header:"Output 2/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7scasdxft30"},
       {header:"Output 3/5", body:"200 CKB -> ckb1qyqw2fsdswd8s6kz4yy3s80e5s3lrma7sc7qffs5ek"},
       {header:"Output 4/5", body:"200 CKB -> ckb1qyq72fsdswd8s6kz4yy3s80e5s3lrma7sc7sgyfcr3"},


### PR DESCRIPTION
The bug occurred because there was only one flag for "sending to
multisig address", this fixes it so there is one flag per output.

Also fixes an issue with five-output transactions, where we were off by
one and had too few prompt screens to actually show the transaction.