### PR TITLE
Fix test suite thunking and version test.

### DIFF
--- a/tests/hw-app-ckb/github.json
+++ b/tests/hw-app-ckb/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "obsidiansystems",
   "repo": "hw-app-ckb",
-  "branch": "develop",
+  "branch": "jg-app-configuration-hash",
   "private": false,
-  "rev": "205fb6c25eb28c8a216fba09cfb37ee37a1c7587",
-  "sha256": "19k1c7n0yy6z7vw8zanpmsssg6sssm8gf8m21mdwdfcaqid5nrlj"
+  "rev": "edfdd0f34d044a997b7e79c676687190b9a5a033",
+  "sha256": "0md3fhz9ll6l1fnrldvzbb0blgsm0npk0h17v30lh8r8f149bwlq"
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -29,14 +29,16 @@
 		"prettier": "^1.18.2",
 		"rxjs": "^6.6.0",
 		"tap": "^14.10.8",
-		"uglify-js": "^3.6.1",
-		"blake2b-wasm": "^2.1.0"
+		"uglify-js": "^3.6.1"
 	},
 	"dependencies": {
 		"hw-app-ckb": "https://github.com/obsidiansystems/hw-app-ckb.git",
+    "@ledgerhq/hw-transport": "^5.9.0",
+    "bech32": "1.1.4",
 		"@ledgerhq/hw-transport-node-speculos": "5.19.1",
 		"@ledgerhq/hw-transport-node-hid": "5.22.0",
 		"bip32-path": "^0.4.2",
+		"blake2b-wasm": "^2.1.0",
 		"create-hash": "1.2.0"
 	}
 }


### PR DESCRIPTION
Because of limitations in the way the hw-app-ckb rebuild is run and the
yarn2nix we use here, we need dependencies of hw-app-ckb in
tests/package.json.

Also bump hw-app-ckb to a version that correctly handles app hash.