### PR TITLE
Add functions for check-installed-version.sh

### DIFF
--- a/check-installed-version.sh
+++ b/check-installed-version.sh
@@ -1,6 +1,13 @@
 #! /usr/bin/env nix-shell
 #! nix-shell -i bash -A wallet.s
-source tests/lib.sh
+
+apdu() {
+  python -m ledgerblue.runScript --apdu
+}
+
+apdu_fixed () {
+  echo "$*" | apdu | sed 's/HID //'
+}
 
 #echo Installed version:
 #apdu_fixed "8000000000"


### PR DESCRIPTION
These functions used to be in tests/lib.sh. That's no longer used, so
we can just provide the relevant functions here.